### PR TITLE
Adding additional libitk references to resolve missing symbols

### DIFF
--- a/configure
+++ b/configure
@@ -60,7 +60,7 @@ echo "libants=\`find \${myantslib} -name \"lib*.a\"\`" >> Makevars
 # echo "libitk=\`find \\\`\$(R_HOME)/bin/Rscript -e 'ITKR:::itkLibs()'\\\` -name \"lib*.a\"\` " >> Makevars
 echo "libitk=\`find ${ITKRLIB} -name \"lib*.a\"\`" >> Makevars
 
-echo "PKG_LIBS=${PKG_LIBS} \${libants} \${libitk} \${libants} \${libitk}" >> Makevars
+echo "PKG_LIBS=${PKG_LIBS} \${libants} \${libitk} \${libants} \${libitk} \${libants} \${libitk} \${libants} \${libitk}" >> Makevars
 
 echo ".PHONY: all libs" >> Makevars
 
@@ -114,3 +114,4 @@ ${cmaker} -DITK_DIR:PATH=${ITKDIR} \
 cd ../
 # needed for warning
 rm -rf ants/.git
+


### PR DESCRIPTION
The following error was showing up when compiling ANTsRCore:
```
unable to load shared object '/usr/lib64/R/library/ANTsR/libs/ANTsRCore.so':
/usr/lib64/R/library/ANTsR/libs/ANTsR.so: undefined symbol: gdcmjpeg16_jpeg_resync_to_restart
```
Looking in library file with `nm` revealed that all of the symbols, `gdcmjpeg16*` were showing as undefined.  Adding additional library references to the `PKG_LIBS` variable enabled enough references for them to be resolved.

A similar fix was already done in ANTsR, commit https://github.com/stnava/ANTsR/commit/9b4173396886b06b395ddd97d644beb2db1af002

I believe that the ANTsR fix removed the first occurence of the unresolved symbols and revealed a second layer, which this will fix.